### PR TITLE
build: fix link error on macOS

### DIFF
--- a/cmake/Toolchain-gcc-clang.cmake
+++ b/cmake/Toolchain-gcc-clang.cmake
@@ -50,7 +50,7 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-ggdb3 -fno-omit-frame-pointer -Wall -Wextra)
 else()
-    add_compile_options(-Ofast -fomit-frame-pointer)
+    add_compile_options(-O3 -ffast-math -fomit-frame-pointer)
 endif()
 
 # for some reason this is necessary

--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -79,7 +79,7 @@ else ifeq ($(platform), classic_armv7_a7)
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	SHARED := -shared -Wl,--no-undefined -fPIC
-	CFLAGS += -Ofast \
+	CFLAGS += -O3 -ffast-math \
 	-flto=4 -fwhole-program -fuse-linker-plugin \
 	-fdata-sections -ffunction-sections -Wl,--gc-sections \
 	-fno-stack-protector -fno-ident -fomit-frame-pointer \
@@ -112,7 +112,7 @@ else ifeq ($(platform), classic_armv8_a35)
 	fpic := -fPIC
 	SHARED := -shared
 	TILED_RENDERING=1
-	CFLAGS += -Ofast \
+	CFLAGS += -O3 -ffast-math \
 	-flto=4 -fwhole-program -fuse-linker-plugin \
 	-fdata-sections -ffunction-sections -Wl,--gc-sections \
 	-fno-stack-protector -fno-ident -fomit-frame-pointer \

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -404,6 +404,9 @@ if(APPLE)
     target_sources(visualboyadvance-m PRIVATE
         macsupport.mm
     )
+
+    target_link_libraries(visualboyadvance-m
+      tiff zstd deflate)
 endif()
 
 # link libgcc/libstdc++ statically on mingw


### PR DESCRIPTION
Add `tiff zstd deflate` to link libs for macOS to fix a link error caused by libzstd and libdeflate not being linked for libtiff which is linked by wxWidgets.